### PR TITLE
Trivial UX fixes

### DIFF
--- a/src/react/components/Program/ProgramCommands.js
+++ b/src/react/components/Program/ProgramCommands.js
@@ -28,7 +28,8 @@ const COMMANDS_QUERY = gql`
 const ProgramCommands = ({ program, mode }) => {
   return (
     <div className="similar-commands mt-2">
-      <h2> Recommended Commands </h2>{" "}
+      <h3>Related Commands</h3>
+      <p>More commands from the {program} program</p>
       <Query query={COMMANDS_QUERY} variables={{ programs: [program] }}>
         {({ loading, error, data: { commands } }) => {
           if (loading) return "Loading";

--- a/src/react/components/Program/SimilarPrograms.js
+++ b/src/react/components/Program/SimilarPrograms.js
@@ -23,7 +23,8 @@ const SIMILAR_PROGRAMS_QUERY = gql`
 const SimilarPrograms = ({ program, platformName }) => {
   return (
     <div className="similar-commands">
-      <h2>Recommended Programs</h2>
+      <h3>Similar Programs</h3>
+      <p>Alternative programs with similar functionality</p>
       <Query
         query={SIMILAR_PROGRAMS_QUERY}
         variables={{ cliName: program, platformName, k: 6 }}


### PR DESCRIPTION
- Using `<h3>` instead of `<h2>` in recommended programs/commands panels
- Improved verbosity